### PR TITLE
elm::Expection inherits directly from std::exception instead of cv::Exception

### DIFF
--- a/modules/elm/core/cv/mat_utils.cpp
+++ b/modules/elm/core/cv/mat_utils.cpp
@@ -7,6 +7,8 @@
 //M*/
 #include "elm/core/cv/mat_utils.h"
 
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/exception.h"
 
 using namespace std;

--- a/modules/elm/core/cv/mat_utils_inl.h
+++ b/modules/elm/core/cv/mat_utils_inl.h
@@ -10,6 +10,8 @@
 #ifndef _ELM_CORE_MAT_UTILS_INL_H__
 #define _ELM_CORE_MAT_UTILS_INL_H__
 
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/cv/typedefs_fwd.h"
 #include "elm/core/defs.h"
 #include "elm/core/exception.h"

--- a/modules/elm/core/cv/mat_vector_utils_inl.h
+++ b/modules/elm/core/cv/mat_vector_utils_inl.h
@@ -10,7 +10,7 @@
 #ifndef _ELM_CORE_MAT_VECTOR_UTILS_INL_H_
 #define _ELM_CORE_MAT_VECTOR_UTILS_INL_H_
 
-#include <vector>
+#include <opencv2/core/core.hpp>    // includes vector too
 
 #include "elm/core/cv/typedefs_fwd.h"
 #include "elm/core/exception.h"

--- a/modules/elm/core/exception.cpp
+++ b/modules/elm/core/exception.cpp
@@ -53,6 +53,8 @@
 //M*/
 #include "elm/core/exception.h"
 
+#include <opencv2/core/core.hpp>
+#include <cmath>
 #include <opencv2/core/operations.hpp>
 #include <opencv2/core/types_c.h>
 

--- a/modules/elm/core/exception.cpp
+++ b/modules/elm/core/exception.cpp
@@ -2,55 +2,141 @@
 //
 // Copyright (c) 2015, Youssef Kashef
 // Copyright (c) 2015, ELM Library Project
-// 3-clause BSD License
+//
+// For class Exception the following applies:
+//      Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+//      Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+//      Third party copyrights are property of their respective owners.
+//
+//      Please see details in section below.
+//M*/
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
 #include "elm/core/exception.h"
 
+#include <opencv2/core/operations.hpp>
 #include <opencv2/core/types_c.h>
 
-using cv::String;
+using std::string;
+using cv::format;
 using namespace elm;
 
-Exception::Exception(int _code, const std::string &msg,
-                     const std::string &_func, const std::string &_file, int _line)
-    : cv::Exception(_code, String(msg),
-                    String(_func), String(_file), _line)
+Exception::Exception()
+    : code(0),
+      line(0)
+{}
+
+Exception::Exception(int _code,
+                     const string& _err,
+                     const string& _func,
+                     const string& _file,
+                     int _line)
+    : code(_code),
+      err(_err),
+      func(_func),
+      file(_file),
+      line(_line)
 {
+    formatMessage();
 }
 
-ExceptionBadDims::ExceptionBadDims(const std::string &msg)
-    : Exception(CV_StsBadSize, String(msg),
+Exception::~Exception() throw() {}
+
+const char* Exception::what() const throw() {
+
+    return msg.c_str();
+}
+
+void Exception::formatMessage() {
+
+    if(func.size() > 0) {
+        msg = format("%s:%d: error: (%d) %s in function %s\n",
+                     file.c_str(),
+                     line,
+                     code,
+                     err.c_str(),
+                     func.c_str());
+    }
+    else {
+        msg = format("%s:%d: error: (%d) %s\n",
+                     file.c_str(),
+                     line,
+                     code,
+                     err.c_str());
+    }
+}
+
+ExceptionBadDims::ExceptionBadDims(const string &msg)
+    : Exception(CV_StsBadSize, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }
 
-ExceptionNotImpl::ExceptionNotImpl(const std::string &msg)
-    : Exception(CV_StsNotImplemented, String(msg),
+ExceptionNotImpl::ExceptionNotImpl(const string &msg)
+    : Exception(CV_StsNotImplemented, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }
 
-ExceptionFileIOError::ExceptionFileIOError(const std::string &msg)
-    : Exception(CV_StsObjectNotFound, String(msg),
+ExceptionFileIOError::ExceptionFileIOError(const string &msg)
+    : Exception(CV_StsObjectNotFound, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }
 
-ExceptionValueError::ExceptionValueError(const std::string &msg)
-    : Exception(CV_StsBadArg, String(msg),
+ExceptionValueError::ExceptionValueError(const string &msg)
+    : Exception(CV_StsBadArg, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }
 
-ExceptionKeyError::ExceptionKeyError(const std::string &msg)
-    : Exception(CV_StsBadArg, String(msg),
+ExceptionKeyError::ExceptionKeyError(const string &msg)
+    : Exception(CV_StsBadArg, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }
 
-ExceptionTypeError::ExceptionTypeError(const std::string &msg)
-    : Exception(CV_StsUnsupportedFormat, String(msg),
+ExceptionTypeError::ExceptionTypeError(const string &msg)
+    : Exception(CV_StsUnsupportedFormat, msg,
                 CV_Func, __FILE__, __LINE__ )
 {
 }

--- a/modules/elm/core/exception.h
+++ b/modules/elm/core/exception.h
@@ -2,13 +2,60 @@
 //
 // Copyright (c) 2015, Youssef Kashef
 // Copyright (c) 2015, ELM Library Project
-// 3-clause BSD License
+//
+// For class Exception the following applies:
+//      Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+//      Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+//      Third party copyrights are property of their respective owners.
+//
+//      Please see details in section below.
+//M*/
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
 #ifndef _ELM_CORE_EXCEPTION_H_
 #define _ELM_CORE_EXCEPTION_H_
 
 #include <string>
+#include <exception>
 #include <opencv2/core/core.hpp>
 
 /** Preprocessor macros for throwing types of Exceptions with custom error messages
@@ -28,11 +75,51 @@
 
 namespace elm {
 
-class Exception : public cv::Exception
+/**
+ * @brief The Exception class adapted from OpenCV's Exception class
+ */
+class Exception : public std::exception
 {
 public:
-    Exception(int _code, const std::string &msg,
-              const std::string &_func, const std::string &_file, int _line);
+    /**
+     * @brief Default constructor
+     */
+    Exception();
+
+    /**
+     * @brief Full constructor. Normally the constuctor is not called explicitly.
+     * Instead, the macros ELM_THROW_* are used.
+     * @param _code error code
+     * @param _err error message
+     * @param _func function in which the error occured
+     * @param _file file in which the function is located
+     * @param _line the line in the file where the error was detected
+     */
+    Exception(int _code,
+              const std::string& _err,
+              const std::string& _func,
+              const std::string& _file,
+              int _line);
+
+    virtual ~Exception() throw();
+
+    /**
+     * @brief the error description and the context as a text string
+     * @return message describing the error
+     */
+    virtual const char *what() const throw();
+
+    /** @brief format the error message
+     */
+    void formatMessage();
+
+    std::string msg;    ///< the formatted error message
+
+    int code;           ///< error code @see CVStatus
+    std::string err;         ///< error description
+    std::string func;        ///< function name. Available only when the compiler supports getting it
+    std::string file;        ///< source file name where the error has occured
+    int line;           ///< line number in the source file where the error has occured
 };
 
 class ExceptionBadDims : public Exception

--- a/modules/elm/core/exception.h
+++ b/modules/elm/core/exception.h
@@ -56,7 +56,6 @@
 
 #include <string>
 #include <exception>
-#include <opencv2/core/core.hpp>
 
 /** Preprocessor macros for throwing types of Exceptions with custom error messages
  */

--- a/modules/elm/core/pcl/cloud_2cloud_.h
+++ b/modules/elm/core/pcl/cloud_2cloud_.h
@@ -10,6 +10,8 @@
 
 #ifdef __WITH_PCL // the template class definitions require PCL support
 
+#include <opencv2/core/core.hpp>
+
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 

--- a/modules/elm/core/pcl/cloud_impl_.h
+++ b/modules/elm/core/pcl/cloud_impl_.h
@@ -10,6 +10,8 @@
 
 #ifdef __WITH_PCL // the following template Converter Cloud Mat class requires PCL support
 
+#include <opencv2/core/core.hpp>
+
 #include <pcl/point_cloud.h>
 
 #include "elm/core/exception.h"

--- a/modules/elm/core/pcl/vertices.cpp
+++ b/modules/elm/core/pcl/vertices.cpp
@@ -9,6 +9,8 @@
 
 #ifdef __WITH_PCL
 
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/exception.h"
 #include "elm/core/cv/mat_utils.h"
 

--- a/modules/elm/core/percentile.cpp
+++ b/modules/elm/core/percentile.cpp
@@ -7,6 +7,7 @@
 //M*/
 #include "elm/core/percentile.h"
 
+#include <opencv2/core/core.hpp>
 #include "elm/core/exception.h"
 
 using namespace cv;

--- a/modules/elm/core/test/area_unittests.cpp
+++ b/modules/elm/core/test/area_unittests.cpp
@@ -8,6 +8,9 @@
 #include "elm/core/area.h"
 
 #include "gtest/gtest.h"
+
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/exception.h"
 
 using cv::Mat1f;

--- a/modules/elm/core/visitors/visitorcloud_.h
+++ b/modules/elm/core/visitors/visitorcloud_.h
@@ -17,6 +17,14 @@
 #include "elm/core/typedefs_sfwd.h"
 #include "elm/core/visitors/visitor_.h"
 
+extern template class pcl::PointCloud<pcl::PointXYZ >;
+extern template class pcl::PointCloud<pcl::Normal >;
+extern template class pcl::PointCloud<pcl::PointNormal >;
+
+extern template class boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ > >;
+extern template class boost::shared_ptr<pcl::PointCloud<pcl::Normal > >;
+extern template class boost::shared_ptr<pcl::PointCloud<pcl::PointNormal > >;
+
 namespace elm {
 
 /**

--- a/modules/elm/core/visitors/visitorpod_.h
+++ b/modules/elm/core/visitors/visitorpod_.h
@@ -10,6 +10,8 @@
 
 #include "elm/core/visitors/visitor_.h"
 
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/exception.h"
 #include "elm/core/cv/mat_utils.h"
 #include "elm/core/cv/sparsemat_utils.h"

--- a/modules/elm/io/base_readermnistfile.cpp
+++ b/modules/elm/io/base_readermnistfile.cpp
@@ -7,6 +7,8 @@
 //M*/
 #include "elm/io/base_readermnistfile.h"
 
+#include <sstream>
+
 #include "elm/core/exception.h"
 #include "elm/core/layeroutputnames.h"
 #include "elm/io/binary.h"

--- a/modules/elm/io/file_serialization.h
+++ b/modules/elm/io/file_serialization.h
@@ -55,9 +55,10 @@ void Save(const boost::filesystem::path &p, const T &obj)
 
     if(!stream.is_open()) {
 
-        std::stringstream s;
-        s << "Failed to open file (" << p.string() << ") for writing.";
-        ELM_THROW_FILEIO_ERROR(s.str());
+        std::string s = "Failed to open file (";
+        s += p.string();
+        s += ") for writing.";
+        ELM_THROW_FILEIO_ERROR(s);
     }
 
     switch(archive_type) {
@@ -103,9 +104,11 @@ void Load(const boost::filesystem::path &p, T &obj)
 
     if(!stream.is_open()) {
 
-        std::stringstream s;
-        s << "Failed to open file (" << p.string() << ") for reading.";
-        ELM_THROW_FILEIO_ERROR(s.str());
+        std::string s;
+        s += "Failed to open file (";
+        s += p.string();
+        s += ") for reading.";
+        ELM_THROW_FILEIO_ERROR(s);
     }
 
     switch(archive_type) {

--- a/modules/elm/io/readmnistlabels.cpp
+++ b/modules/elm/io/readmnistlabels.cpp
@@ -7,6 +7,8 @@
 //M*/
 #include "elm/io/readmnistlabels.h"
 
+#include <opencv2/core/core.hpp>
+
 #include "elm/core/exception.h"
 #include "elm/core/signal.h"
 #include "elm/ts/layerattr_.h"

--- a/modules/elm/layers/test/gradassignment_unittests.cpp
+++ b/modules/elm/layers/test/gradassignment_unittests.cpp
@@ -430,7 +430,7 @@ TEST_F(GradAssignmentTest, MoreNoise)
 
         // add more noise to g_ij_ for next iteration
         Mat1f noise(g_ij_.size());
-        randn(noise, 0.f, 0.05f);
+        randn(noise, 0.f, 0.1f);
         g_ij_ += noise;
         g_ij_.setTo(0.f, g_ij_ < 0.f);
         g_ij_.setTo(1.f, g_ij_ > 1.f);

--- a/modules/elm/ts/fakemnistlabelswriter.cpp
+++ b/modules/elm/ts/fakemnistlabelswriter.cpp
@@ -7,6 +7,8 @@
 //M*/
 #include "elm/ts/fakemnistlabelswriter.h"
 
+#include <sstream>
+
 #include "elm/core/exception.h"
 #include "elm/io/binary.h"              // determine and swap endianness
 

--- a/modules/elm/ts/ts.h
+++ b/modules/elm/ts/ts.h
@@ -15,8 +15,6 @@
 
 #include "gtest/gtest.h"
 
-#include <string>
-
 #include "elm/ts/interval.h"
 #include "elm/ts/mat_assertions.h"
 #include "elm/ts/container.h"


### PR DESCRIPTION
Reduces unnecessary include of entire opencv core header.